### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/adminer/.env.template
+++ b/adminer/.env.template
@@ -1,3 +1,5 @@
+# nginx-proxy / acme-companion: LETSENCRYPT_HOST should match VIRTUAL_HOST for certs. Leave
+# LETSENCRYPT_EMAIL empty if userver-web letsencrypt/.env sets DEFAULT_EMAIL (avoid duplicate emails).
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

## Scope
<!-- Describe all the changes briefly with bullet points. -->

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [ ] My code follows the code style
- [ ] Created all unit/e2e tests needed
- [ ] All lints and tests passed correctly
- [ ] I upgraded dependencies to the latest working version

:heart: Thank you!
