### PR TITLE
fix(postgres): honor POSTGRES_USER in healthcheck and document uServe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ cp postgres/.env.template postgres/.env
 ``` 
 ...and edit them accordingly.
 
+Set **`postgres/.env`** **`POSTGRES_USER`** and **`POSTGRES_PASSWORD`** to the database superuser you want created on **first** startup (empty `dbdata` volume). The [official PostgreSQL image](https://hub.docker.com/_/postgres) only reads these on initial cluster creation. If you deploy with the **uServer** orchestration repo, use the same name as **`USERVER_DB_USER`** and the same password as **`USERVER_DB_PASSWORD`** so services that run `psql -U "$USERVER_DB_USER"` can administer the instance. Set **`backup/.env`** **`POSTGRES_USER`** to that same superuser so backups authenticate correctly.
+
 ### Run the Application
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      # Must match POSTGRES_USER in postgres/.env (defaults to postgres if unset).
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER:-postgres}\""]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/postgres/.env.template
+++ b/postgres/.env.template
@@ -1,2 +1,4 @@
+# Superuser created on first init (empty data volume). When using uServer orchestration, set this to the same value as USERVER_DB_USER in the stack .env.
+POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
 PGDATA=/var/lib/postgresql/data/pgdata


### PR DESCRIPTION
…r USERVER_DB_USER

- Add POSTGRES_USER to postgres/.env.template (default postgres) with uServer note
- Healthcheck uses pg_isready against $POSTGRES_USER so custom superuser names work
- README: align POSTGRES_USER/POSTGRES_PASSWORD and backup POSTGRES_USER with orchestration

## Scope
<!-- Describe all the changes briefly with bullet points. -->

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [ ] My code follows the code style
- [ ] Created all unit/e2e tests needed
- [ ] All lints and tests passed correctly
- [ ] I upgraded dependencies to the latest working version

:heart: Thank you!
